### PR TITLE
Update code to make use of the cleanup that has been done on search tasks

### DIFF
--- a/exportpermission.civix.php
+++ b/exportpermission.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Exportpermission_ExtensionUtil {
+  const SHORT_NAME = "exportpermission";
+  const LONG_NAME = "net.ourpowerbase.exportpermission";
+  const CLASS_PREFIX = "CRM_Exportpermission";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Exportpermission_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -190,12 +267,12 @@ function _exportpermission_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'net.ourpowerbase.exportpermission';
+        $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -222,7 +299,7 @@ function _exportpermission_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'net.ourpowerbase.exportpermission',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -248,7 +325,7 @@ function _exportpermission_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'net.ourpowerbase.exportpermission';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -275,8 +352,10 @@ function _exportpermission_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _exportpermission_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -365,4 +444,17 @@ function _exportpermission_civix_civicrm_alterSettingsFolders(&$metaDataFolders 
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _exportpermission_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+  ));
 }

--- a/exportpermission.php
+++ b/exportpermission.php
@@ -17,23 +17,9 @@ function exportpermission_civicrm_searchTasks($objectName, &$tasks) {
     // If they have the proper permission, return without doing anything.
     return;
   }
-  // $tasks is not properly keyed, so we have to iterate over all of them to find
-  // any permissions that involve an export form.
-  reset($tasks);
-  while(list($k, $value) = each($tasks)) {
-    $regexp = '/^CRM_Export_Form/';
-    if(is_array($value['class'])) {
-      if(preg_grep($regexp, $value['class'])) {
-        unset($tasks[$k]);
-      }
-    }
-    elseif(preg_match($regexp, $value['class'])) {
-      unset($tasks[$k]);
-    }
-  }
-  reset($tasks);
+  unset($tasks[CRM_Core_Task::TASK_EXPORT]);
 }
-  
+
 /**
  * Implements hook_civicrm_config().
  *

--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/progressivetech/net.ourpowerbase.exportpermission/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-02-27</releaseDate>
+  <releaseDate>2018-11-01</releaseDate>
   <version>1.0</version>
-  <develStage>alpha</develStage>
+  <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.6</ver>
   </compatibility>
   <comments>This extensions does not stop people from exporting data, it only hides the action from the menu.</comments>
   <civix>


### PR DESCRIPTION
Earlier in the 5.x series @mattwire did a big cleanup on search tasks & we can use this now. I'm not sure exactly which release but 5.6 is the current one so just picking that seems fine.

 Since this was not previously on the extensions directly I think the current 'user' is PTP & I don't expect @jmcclelland  to have any difficulty navigating not deploying the version
with the cleaned up code on old Civi releases (I think 5.3 actually does have the fixes in it which is possibly what you are on)