### PR TITLE
Report + Print/PDF/Labels permissions

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Package: net.ourpowerbase.exportpermission
-Copyright (C) 2017, Jamie McClelland <jm@mayfirst.org>
+Copyright (C) 2021, Jamie McClelland <jm@mayfirst.org>
 Licensed under the GNU Affero Public License 3.0 (below).
 
 -------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ When this extension is enabled, users that are not explicitly granted this
 permission do not see the export options listed in the "Actions" dropdown for Searches/Reports.
 
 ### Warning:
-This extension does not technically prevent a user from
-exporting a CiviCRM database, it *only* removes that option from the Actions
-drop down list. Enterprising hackers can figure out ways to convince CiviCRM to
+This extension removes the export options from the actions menu and removes access to most of
+the export forms but there will always be ways to extract the data.
+
+Enterprising hackers can figure out ways to convince CiviCRM to
 provide the export. Additionally, any user that can view all Contacts can
 export the data one way or another - even if it means copy and pasting from
 each screen.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Export Permission
 
 The Export Permission extension is designed to help restrict who has the
-ability to export records in your database. 
+ability to export records in your database.
 
-It adds a new permission that allows the Export option to appear in the drop
-down Actions menu after a search.
+### It adds the following new permissions:
 
-When this extension is enbled, users that are not explicitly granted this
-permission do not see the Export option listed.
+- CiviCRM Export Permissions: access export menu - Access "Export as CSV" drop down menu item from actions menu on after search/report.
+- CiviCRM Export Permissions: access print menu - Access "Print" drop down menu item from actions menu on search/report.
+- CiviCRM Export Permissions: access print pdf menu - Access "Print/Merge document (PDF Letter)" drop down menu item from actions menu on search/report'.
 
-**Please note**, this extension does not technically prevent a user from
+When this extension is enabled, users that are not explicitly granted this
+permission do not see the export options listed in the "Actions" dropdown for Searches/Reports.
+
+### Warning:
+This extension does not technically prevent a user from
 exporting a CiviCRM database, it *only* removes that option from the Actions
 drop down list. Enterprising hackers can figure out ways to convince CiviCRM to
 provide the export. Additionally, any user that can view all Contacts can
 export the data one way or another - even if it means copy and pasting from
 each screen.
-
-Additionally, if you don't want a user to have the export option, be sure to
-remove their permission to access CiviReports (since CiviReports provides a
-different path to exporting records).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ ability to export records in your database.
 
 - CiviCRM Export Permissions: access export menu - Access "Export as CSV" drop down menu item from actions menu on after search/report.
 - CiviCRM Export Permissions: access print menu - Access "Print" drop down menu item from actions menu on search/report.
-- CiviCRM Export Permissions: access print pdf menu - Access "Print/Merge document (PDF Letter)" drop down menu item from actions menu on search/report'.
+- CiviCRM Export Permissions: access print pdf menu - Access "Print/Merge document (PDF Letter)" drop down menu item from actions menu on search/report.
+- CiviCRM Export Permissions: access mailing labels menu - Access "Print Mailing Labels" drop down menu item from actions menu on search/report.
 
 When this extension is enabled, users that are not explicitly granted this
 permission do not see the export options listed in the "Actions" dropdown for Searches/Reports.

--- a/exportpermission.civix.php
+++ b/exportpermission.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Exportpermission_ExtensionUtil {
-  const SHORT_NAME = "exportpermission";
-  const LONG_NAME = "net.ourpowerbase.exportpermission";
-  const CLASS_PREFIX = "CRM_Exportpermission";
+  const SHORT_NAME = 'exportpermission';
+  const LONG_NAME = 'net.ourpowerbase.exportpermission';
+  const CLASS_PREFIX = 'CRM_Exportpermission';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Exportpermission_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -82,7 +82,7 @@ use CRM_Exportpermission_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _exportpermission_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -100,7 +100,7 @@ function _exportpermission_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -112,7 +112,7 @@ function _exportpermission_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _exportpermission_civix_civicrm_xmlMenu(&$files) {
   foreach (_exportpermission_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -123,7 +123,7 @@ function _exportpermission_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _exportpermission_civix_civicrm_install() {
   _exportpermission_civix_civicrm_config();
@@ -135,12 +135,12 @@ function _exportpermission_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _exportpermission_civix_civicrm_postInstall() {
   _exportpermission_civix_civicrm_config();
   if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +149,7 @@ function _exportpermission_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _exportpermission_civix_civicrm_uninstall() {
   _exportpermission_civix_civicrm_config();
@@ -161,12 +161,12 @@ function _exportpermission_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _exportpermission_civix_civicrm_enable() {
   _exportpermission_civix_civicrm_config();
   if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -175,13 +175,13 @@ function _exportpermission_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _exportpermission_civix_civicrm_disable() {
   _exportpermission_civix_civicrm_config();
   if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +193,11 @@ function _exportpermission_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _exportpermission_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _exportpermission_civix_upgrader()) {
@@ -217,52 +218,31 @@ function _exportpermission_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _exportpermission_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_exportpermission_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _exportpermission_civix_civicrm_managed(&$entities) {
   $mgdFiles = _exportpermission_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
@@ -284,7 +264,7 @@ function _exportpermission_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _exportpermission_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -295,14 +275,13 @@ function _exportpermission_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -313,7 +292,7 @@ function _exportpermission_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _exportpermission_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -332,6 +311,25 @@ function _exportpermission_civix_civicrm_angularModules(&$angularModules) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _exportpermission_civix_civicrm_themes(&$themes) {
+  $files = _exportpermission_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -341,11 +339,12 @@ function _exportpermission_civix_civicrm_angularModules(&$angularModules) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _exportpermission_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
@@ -356,16 +355,18 @@ function _exportpermission_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _exportpermission_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +377,9 @@ function _exportpermission_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _exportpermission_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _exportpermission_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +390,7 @@ function _exportpermission_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _exportpermission_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _exportpermission_civix_fixNavigationMenu($nodes);
   }
 }
@@ -431,17 +432,11 @@ function _exportpermission_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $pa
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _exportpermission_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
@@ -451,8 +446,8 @@ function _exportpermission_civix_civicrm_alterSettingsFolders(&$metaDataFolders 
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
 function _exportpermission_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array());
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/exportpermission.php
+++ b/exportpermission.php
@@ -22,8 +22,6 @@ function exportpermission_civicrm_searchTasks($objectName, &$tasks) {
 
 /**
  * Implements hook_civicrm_config().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
  */
 function exportpermission_civicrm_config(&$config) {
   _exportpermission_civix_civicrm_config($config);
@@ -31,8 +29,6 @@ function exportpermission_civicrm_config(&$config) {
 
 /**
  * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
  */
 function exportpermission_civicrm_xmlMenu(&$files) {
   _exportpermission_civix_civicrm_xmlMenu($files);
@@ -40,8 +36,6 @@ function exportpermission_civicrm_xmlMenu(&$files) {
 
 /**
  * Implements hook_civicrm_install().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function exportpermission_civicrm_install() {
   _exportpermission_civix_civicrm_install();
@@ -49,8 +43,6 @@ function exportpermission_civicrm_install() {
 
 /**
  * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
  */
 function exportpermission_civicrm_postInstall() {
   _exportpermission_civix_civicrm_postInstall();
@@ -58,8 +50,6 @@ function exportpermission_civicrm_postInstall() {
 
 /**
  * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
  */
 function exportpermission_civicrm_uninstall() {
   _exportpermission_civix_civicrm_uninstall();
@@ -67,8 +57,6 @@ function exportpermission_civicrm_uninstall() {
 
 /**
  * Implements hook_civicrm_enable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function exportpermission_civicrm_enable() {
   _exportpermission_civix_civicrm_enable();
@@ -76,8 +64,6 @@ function exportpermission_civicrm_enable() {
 
 /**
  * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
  */
 function exportpermission_civicrm_disable() {
   _exportpermission_civix_civicrm_disable();
@@ -85,8 +71,6 @@ function exportpermission_civicrm_disable() {
 
 /**
  * Implements hook_civicrm_upgrade().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
  */
 function exportpermission_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   return _exportpermission_civix_civicrm_upgrade($op, $queue);
@@ -97,35 +81,15 @@ function exportpermission_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  *
  * Generate a list of entities to create/deactivate/delete when this module
  * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
  */
 function exportpermission_civicrm_managed(&$entities) {
   _exportpermission_civix_civicrm_managed($entities);
 }
 
 /**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function exportpermission_civicrm_caseTypes(&$caseTypes) {
-  _exportpermission_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
  * Implements hook_civicrm_angularModules().
  *
  * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
  */
 function exportpermission_civicrm_angularModules(&$angularModules) {
   _exportpermission_civix_civicrm_angularModules($angularModules);
@@ -133,8 +97,6 @@ function exportpermission_civicrm_angularModules(&$angularModules) {
 
 /**
  * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
  */
 function exportpermission_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _exportpermission_civix_civicrm_alterSettingsFolders($metaDataFolders);

--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/progressivetech/net.ourpowerbase.exportpermission/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-11-01</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2021-07-21</releaseDate>
+  <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.6</ver>
+    <ver>5.35</ver>
   </compatibility>
   <comments>This extensions does not stop people from exporting data, it only hides the action from the menu.</comments>
   <civix>


### PR DESCRIPTION
This adds support for reports and adds permissions for "Print", "PDF Letter" (Print/Merge document) and mailing labels.
Also adds a permission check in buildForm that should detect most forms if accessed directly.

Also regenerate civix for compatibility with PHP7.4