### PR TITLE
Run civix upgrade

### DIFF
--- a/exportpermission.civix.php
+++ b/exportpermission.civix.php
@@ -79,40 +79,22 @@ class CRM_Exportpermission_ExtensionUtil {
 
 use CRM_Exportpermission_ExtensionUtil as E;
 
-function _exportpermission_civix_mixin_polyfill() {
-  if (!class_exists('CRM_Extension_MixInfo')) {
-    $polyfill = __DIR__ . '/mixin/polyfill.php';
-    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
-  }
-}
-
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _exportpermission_civix_civicrm_config(&$config = NULL) {
+function _exportpermission_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-  _exportpermission_civix_mixin_polyfill();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -122,36 +104,7 @@ function _exportpermission_civix_civicrm_config(&$config = NULL) {
  */
 function _exportpermission_civix_civicrm_install() {
   _exportpermission_civix_civicrm_config();
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-  _exportpermission_civix_mixin_polyfill();
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _exportpermission_civix_civicrm_postInstall() {
-  _exportpermission_civix_civicrm_config();
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _exportpermission_civix_civicrm_uninstall() {
-  _exportpermission_civix_civicrm_config();
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -159,59 +112,9 @@ function _exportpermission_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _exportpermission_civix_civicrm_enable() {
+function _exportpermission_civix_civicrm_enable(): void {
   _exportpermission_civix_civicrm_config();
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-  _exportpermission_civix_mixin_polyfill();
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _exportpermission_civix_civicrm_disable() {
-  _exportpermission_civix_civicrm_config();
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _exportpermission_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _exportpermission_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Exportpermission_Upgrader
- */
-function _exportpermission_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Exportpermission/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Exportpermission_Upgrader_Base::instance();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -230,8 +133,8 @@ function _exportpermission_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -294,15 +197,4 @@ function _exportpermission_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $pa
       _exportpermission_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _exportpermission_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/exportpermission.php
+++ b/exportpermission.php
@@ -23,38 +23,10 @@ function exportpermission_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- */
-function exportpermission_civicrm_postInstall() {
-  _exportpermission_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- */
-function exportpermission_civicrm_uninstall() {
-  _exportpermission_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  */
 function exportpermission_civicrm_enable() {
   _exportpermission_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- */
-function exportpermission_civicrm_disable() {
-  _exportpermission_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- */
-function exportpermission_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _exportpermission_civix_civicrm_upgrade($op, $queue);
 }
 
 /**
@@ -154,13 +126,4 @@ function exportpermission_civicrm_buildForm($formName, &$form) {
   if ($bounce) {
     CRM_Core_Error::statusBounce(E::ts('You do not have permission to access this page.'));
   }
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function exportpermission_civicrm_entityTypes(&$entityTypes) {
-  _exportpermission_civix_civicrm_entityTypes($entityTypes);
 }

--- a/info.xml
+++ b/info.xml
@@ -23,6 +23,9 @@
   <comments>This extensions does not stop people from exporting data, it only hides the action from the menu.</comments>
   <civix>
     <namespace>CRM/Exportpermission</namespace>
-    <format>22.05.2</format>
+    <format>23.02.1</format>
   </civix>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>


### PR DESCRIPTION
This allows people on the latest CiviCRM to switch to Smarty 3 (which hopefully performs bettter) without notices

Note that this extension is already updated to 1.3 in the info.xml so it would be good if you could tag that once this is merged

- the switch is done via a define in civicrm.settings.php
```
if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
  define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
}
```

