### PR TITLE
Increment version

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/progressivetech/net.ourpowerbase.exportpermission/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-09-27l</releaseDate>
-  <version>1.3</version>
+  <releaseDate>2024-05-04</releaseDate>
+  <version>1.4</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.53</ver>
+    <ver>5.70</ver>
   </compatibility>
   <comments>This extensions does not stop people from exporting data, it only hides the action from the menu.</comments>
   <civix>


### PR DESCRIPTION
Changes to the permission hook required by 5.7x have already been merged but no release tagged

@jmcclelland - this would also require you to tag a release